### PR TITLE
Fix error with variables in docker entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Difference from [teknologist's](https://github.com/rshipp/webNUT) version:
 - switch to python3-alpine3.20 as base image to reduce image size (900Mb -> 80Mb)
 - added actions to build image and publish to docker hub.
-- add healtch check
+- add health check
 - add volume /config to persist config.
 
 # docker-webNUT

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -21,11 +21,11 @@ while true; do
   res="$(curl -m2 -v telnet://${upshost}:${upsport} 2>&1)" || true
   if [[ $res =~ [Cc]onnected ]]; then
     break
-    else echo "Waiting, cannot connect to ${UPS_HOST}:${UPS_PORT}"
+    else echo "Waiting, cannot connect to ${upshost}:${upsport}"
   fi
   sleep 1
 done
 
 cd /app/webNUT/webnut
-echo "Connecting to ${UPS_USER}@${UPS_HOST}:${UPS_PORT}"
+echo "Connecting to ${upsuser}@${upshost}:${upsport}"
 exec pserve /app/webNUT/production.ini


### PR DESCRIPTION
Thanks for the repo, I've been using it for a while!

Noticed that my image is not starting with the error: `/docker-entrypoint.sh: line 30: UPS_USER: unbound variable`.
Cause seems to be in b3a81ceb8e4a7c1557b352a8ab57a38c39b10771, some `UPS_*` variables are used instead of the `ups*` ones which have a fallback. Since I relied on the default values these were unbound. I believe the changes in my commit should fix them.
Until then I just set the default ones in my docker compose file.